### PR TITLE
feat: add support for remote entity

### DIFF
--- a/src/homeassistant.h
+++ b/src/homeassistant.h
@@ -103,6 +103,8 @@ class HomeAssistant : public Integration {
     void onHeartbeat();
     void onHeartbeatTimeout();
 
+    QStringList findRemoteCodes(const QString &feature, const QVariantList &list);
+
     /**
      * @brief Returns a list of supported features converted from the Home Assistant format
      */


### PR DESCRIPTION
Codes can now be configured and will be sent as the command to the Home Assistant service. Setting a format is not required, as there is no variation - everything is just a string and the individual integration in Home Assistant decodes it how it needs to. There is no support in the web configurator for this yet of course, but here is an example for an Apple TV remote entity:

```json
{
    "entities": {
      "remote": [
            {
                "entity_id": "remote.apple_tv",
                "friendly_name": "Apple TV",
                "integration": "some-id",
                "supported_features": ["CURSOR_LEFT"],
                "commands": [
                  {
                    "code": "left",
                    "button_map": "CURSOR_LEFT"
                  }
                ]
            }
        ]
    }
}
```

For now it is only possible to set the `command` and `entity_id` parts of the `remote.send_command` service call. There are some more settings available (`device` is especially interesting to get Harmony Hubs to work), but this is a solid start imo.