### PR TITLE
fix: convert cover position

### DIFF
--- a/src/homeassistant.cpp
+++ b/src/homeassistant.cpp
@@ -363,7 +363,7 @@ void HomeAssistant::updateBlind(EntityInterface *entity, const QVariantMap &attr
     // position
     if (entity->isSupported(BlindDef::F_POSITION)) {
         entity->updateAttrByIndex(BlindDef::POSITION,
-                                  attr.value("attributes").toMap().value("current_position").toInt());
+                                  100 - attr.value("attributes").toMap().value("current_position").toInt());
     }
 }
 


### PR DESCRIPTION
As discussed on Discord: In HA 0 means fully closed and 100 means open, YIO considers it to be the other way around ([source](https://github.com/home-assistant/core/blob/dev/homeassistant/components/cover/__init__.py#L174)).

I verified this tiny fix with my own blind.