### PR TITLE
added device support for broadlink

### DIFF
--- a/src/homeassistant.cpp
+++ b/src/homeassistant.cpp
@@ -597,7 +597,7 @@ void HomeAssistant::sendCommand(const QString &type, const QString &entity_id, i
         if (remoteCodes.length() > 0) {
             QVariantMap data;
 
-            if(remoteDevice.length() > 0) {
+            if (remoteDevice.length() > 0) {
                 data.insert("device", remoteDevice);
             }
 
@@ -608,16 +608,15 @@ void HomeAssistant::sendCommand(const QString &type, const QString &entity_id, i
 }
 
 QString HomeAssistant::findRemoteDevice(const QString &feature, const QVariantList &list) {
-    QString r;
 
     for (int i = 0; i < list.length(); i++) {
         QVariantMap map = list[i].toMap();
         if (map.value("button_map").toString() == feature) {
-            r += map.value("device").toString();
+            return map.value("device").toString();
         }
     }
 
-    return r;
+    return "";
 }
 
 QStringList HomeAssistant::findRemoteCodes(const QString &feature, const QVariantList &list) {

--- a/src/homeassistant.cpp
+++ b/src/homeassistant.cpp
@@ -608,7 +608,6 @@ void HomeAssistant::sendCommand(const QString &type, const QString &entity_id, i
 }
 
 QString HomeAssistant::findRemoteDevice(const QString &feature, const QVariantList &list) {
-
     for (int i = 0; i < list.length(); i++) {
         QVariantMap map = list[i].toMap();
         if (map.value("button_map").toString() == feature) {

--- a/src/homeassistant.cpp
+++ b/src/homeassistant.cpp
@@ -592,13 +592,32 @@ void HomeAssistant::sendCommand(const QString &type, const QString &entity_id, i
         RemoteInterface *remoteInterface = static_cast<RemoteInterface *>(entity->getSpecificInterface());
         QVariantList commands = remoteInterface->commands();
         QStringList remoteCodes = findRemoteCodes(entity->getCommandName(command), commands);
+        QString remoteDevice = findRemoteDevice(entity->getCommandName(command), commands);
 
         if (remoteCodes.length() > 0) {
             QVariantMap data;
+
+            if(remoteDevice.length() > 0) {
+                data.insert("device", remoteDevice);
+            }
+
             data.insert("command", remoteCodes);
             webSocketSendCommand(type, "send_command", entity_id, &data);
         }
     }
+}
+
+QString HomeAssistant::findRemoteDevice(const QString &feature, const QVariantList &list) {
+    QString r;
+
+    for (int i = 0; i < list.length(); i++) {
+        QVariantMap map = list[i].toMap();
+        if (map.value("button_map").toString() == feature) {
+            r += map.value("device").toString();
+        }
+    }
+
+    return r;
 }
 
 QStringList HomeAssistant::findRemoteCodes(const QString &feature, const QVariantList &list) {

--- a/src/homeassistant.h
+++ b/src/homeassistant.h
@@ -104,6 +104,7 @@ class HomeAssistant : public Integration {
     void onHeartbeatTimeout();
 
     QStringList findRemoteCodes(const QString &feature, const QVariantList &list);
+    QString findRemoteDevice(const QString &feature, const QVariantList &list);
 
     /**
      * @brief Returns a list of supported features converted from the Home Assistant format


### PR DESCRIPTION
To make use of the Broadlink integration as a ir extender it is necessary to send the device key with the command to homeassistant. To use it add device property to your command. I am not really aware how you add that in the config.json, if you have a look and let me know I will improve my pr.